### PR TITLE
feat: New emplate email for reset passowrd

### DIFF
--- a/templates/plugin/CakeDC/Users/email/html/reset_password.php
+++ b/templates/plugin/CakeDC/Users/email/html/reset_password.php
@@ -1,0 +1,318 @@
+<?php
+
+/**
+ * Copyright 2024 ACGAMES - anthonyzok521@gmail.com
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2010 - 2018, Cake Development Corporation (https://www.cakedc.com)
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * 
+ * Template html for the email reset password
+ * 
+ */
+
+?>
+
+<table border="0" cellpadding="0" cellspacing="0" class="nl-container" role="presentation" width="100%">
+    <tbody>
+        <tr>
+            <td>
+                <table align="center" border="0" cellpadding="0" cellspacing="0" class="row row-1" role="presentation" width="100%">
+                    <tbody>
+                        <tr style="background-color: #cfd6f4;">
+                            <td>
+                                <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" width="600">
+                                    <tbody>
+                                        <tr>
+                                            <td class="column column-1" width="100%">
+                                                <table border="0" cellpadding="0" cellspacing="0" class="image_block block-1" role="presentation" width="100%">
+                                                    <tr>
+                                                        <td class="pad" style="width: 100%">
+                                                            <div align="center" class="alignment">
+                                                                <div style="max-width: 600px">
+                                                                    <img alt="Card Header with Border and Shadow Animated" height="auto" src="https://i.imgur.com/zH3iIwZ.png" title="Card Header with Border and Shadow Animated" width="600" />
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <table align="center" border="0" cellpadding="0" cellspacing="0" class="row row-2" style="background-position: top center;
+        background-repeat: repeat;
+        background-image: url('https://i.imgur.com/etoKaho.png');" role="presentation" width="100%">
+                    <tbody>
+                        <tr>
+                            <td>
+                                <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" width="600">
+                                    <tbody>
+                                        <tr>
+                                            <td class="column column-1" style="
+                        padding-bottom: 15px;
+                        padding-left: 50px;
+                        padding-right: 50px;
+                        padding-top: 15px;" width="100%">
+                                                <table border="0" cellpadding="10" cellspacing="0" class="paragraph_block block-1" role="presentation" width="100%">
+                                                    <tr>
+                                                        <td class="pad">
+                                                            <div>
+                                                                <p>
+                                                                    <strong><span>Restablecer contraseña</span></strong>
+                                                                </p>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                                <table border="0" cellpadding="10" cellspacing="0" class="paragraph_block block-2" role="presentation" width="100%">
+                                                    <tr>
+                                                        <td class="pad">
+                                                            <div style="
+                                color: #40507a;
+                                font-size: 16px;
+                                mso-line-height-alt: 19.2px;
+                            ">
+                                                                <p>
+                                                                    <span>¡Hola <?= __d('cake_d_c/users', "{0}", isset($first_name) ? $first_name : '') ?>!</span> Hemos recibido
+                                                                    una solicitud para restablecer tu
+                                                                    contraseña.
+                                                                </p>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                                <table border="0" cellpadding="10" cellspacing="0" class="paragraph_block block-3" role="presentation" width="100%">
+                                                    <tr>
+                                                        <td class="pad">
+                                                            <div style="
+                                color: #40507a;
+                                font-size: 16px;
+                                mso-line-height-alt: 19.2px;">
+                                                                <p>
+                                                                    <span>Haz click en el botón.</span>
+                                                                </p>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                                <table border="0" cellpadding="0" cellspacing="0" class="button_block block-4" role="presentation" width="100%">
+                                                    <tr>
+                                                        <td class="pad" style="
+                            padding-bottom: 20px;
+                            padding-left: 10px;
+                            padding-right: 10px;
+                            padding-top: 20px;
+                            text-align: left;
+                            ">
+                                                            <div align="left" class="alignment" style="text-align: -webkit-center;">
+                                                                <a href="<?= $this->Url->build($activationUrl) ?>" target="_blank"><span><span><span data-mce-><strong>RESTABLECER CONTRASEÑA</strong></span></span></span></a>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                                <table border="0" cellpadding="10" cellspacing="0" class="paragraph_block block-5" role="presentation" width="100%">
+                                                    <tr>
+                                                        <td class="pad">
+                                                            <div style="
+                                color: #40507a;
+                                font-size: 14px;
+                                mso-line-height-alt: 16.8px;">
+                                                                <p>
+                                                                    <span>¿Tienes problemas?
+                                                                    </span>
+                                                                </p>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                                <table border="0" cellpadding="10" cellspacing="0" class="paragraph_block block-6" role="presentation" width="100%">
+                                                    <tr>
+                                                        <td class="pad">
+                                                            <div style="
+                                color: #40507a;
+                                font-size: 14px;
+                                mso-line-height-alt: 16.8px;">
+                                                                <p style="margin: 0">
+                                                                    Si no puedes hacer click en el botón,
+                                                                    copia y pega el siguiente enlace en un
+                                                                    navegador: <?= $this->Url->build($activationUrl) ?>
+                                                                </p>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <table align="center" border="0" cellpadding="0" cellspacing="0" class="row row-3" role="presentation" width="100%">
+                    <tbody>
+                        <tr>
+                            <td>
+                                <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" width="600">
+                                    <tbody>
+                                        <tr>
+                                            <td class="column column-1" style="
+                        padding-bottom: 5px;
+                    " width="100%">
+                                                <table border="0" cellpadding="0" cellspacing="0" class="image_block block-1" role="presentation" width="100%">
+                                                    <tr>
+                                                        <td class="pad" style="width: 100%">
+                                                            <div align="center" class="alignment" style="line-height: 10px">
+                                                                <div style="max-width: 600px">
+                                                                    <img alt="Card Bottom with Border and Shadow Image" height="auto" src="https://i.imgur.com/1vrhMWO.png" title="Card Bottom with Border and Shadow Image" width="600" />
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <table align="center" border="0" cellpadding="0" cellspacing="0" class="row row-4" role="presentation" width="100%">
+                    <tbody>
+                        <tr>
+                            <td>
+                                <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" width="600">
+                                    <tbody>
+                                        <tr>
+                                            <td class="column column-1" style="
+                        padding-bottom: 20px;
+                        padding-left: 10px;
+                        padding-right: 10px;
+                        padding-top: 10px;
+                    " width="100%">
+                                                <table border="0" cellpadding="10" cellspacing="0" class="image_block block-1" role="presentation" width="100%">
+                                                    <tr>
+                                                        <td class="pad">
+                                                            <div align="center" class="alignment" style="line-height: 10px;">
+                                                                <div style="max-width: 145px;">
+                                                                    <img alt="UNERG" height="auto" src="https://i.imgur.com/7RFp3ws.png" title="UNERG" width="145" style="margin: auto;"/>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                                <table border="0" cellpadding="10" cellspacing="0" class="paragraph_block block-2" role="presentation" width="100%">
+                                                    <tr>
+                                                        <td class="pad">
+                                                            <div style="
+                                color: #97a2da;
+                                font-size: 14px;
+                                text-align: center;
+                                mso-line-height-alt: 16.8px;
+                            ">
+                                                                <p>
+                                                                    --------------------------------------
+                                                                </p>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                                <table border="0" cellpadding="10" cellspacing="0" class="paragraph_block block-3" role="presentation" width="100%">
+                                                    <tr>
+                                                        <td class="pad">
+                                                            <div style="
+                                color: #97a2da;     font-size: 14px;
+                                text-align: center;
+                                mso-line-height-alt: 16.8px;
+                            ">
+                                                                <p>
+                                                                    No responder este correo
+                                                                </p>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                                <table border="0" cellpadding="10" cellspacing="0" class="paragraph_block block-4" role="presentation" width="100%">
+                                                    <tr>
+                                                        <td class="pad">
+                                                            <div style="
+                                color: #97a2da;
+                                font-size: 12px;
+                                line-height: 120%;
+                                text-align: center;
+                                mso-line-height-alt: 14.399999999999999px;
+                            ">
+                                                                <p>
+                                                                    <span>Copyright© 2024 COSECA AIS</span>
+                                                                </p>
+                                                                <p style="margin: 0; word-break: break-word">
+                                                                     
+                                                                </p>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <table align="center" border="0" cellpadding="0" cellspacing="0" class="row row-5" role="presentation" width="100%">
+                    <tbody>
+                        <tr>
+                            <td>
+                                <table align="center" border="0" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" width="600">
+                                    <tbody>
+                                        <tr>
+                                            <td class="column column-1" style="
+                        padding-bottom: 5px;
+                        padding-top: 5px;
+                    " width="100%">
+                                                <table border="0" cellpadding="0" cellspacing="0" class="icons_block block-1" role="presentation" style="
+                        text-align: center;
+                        " width="100%">
+                                                    <tr>
+                                                        <td class="pad" style="
+                            vertical-align: middle;
+                            color: #1e0e4b;
+                            font-family: 'Inter', sans-serif;
+                            font-size: 15px;
+                            padding-bottom: 5px;
+                            padding-top: 5px;
+                            text-align: center;
+                            ">
+                                                            <table cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                                                                <tr>
+                                                                    <td class="alignment" style="
+                                    vertical-align: middle;
+                                    text-align: center;
+                                ">
+                                                                    </td>
+                                                                </tr>
+                                                            </table>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/templates/plugin/CakeDC/Users/layout/email/html/default.php
+++ b/templates/plugin/CakeDC/Users/layout/email/html/default.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Copyright 2024 ACGAMES - anthonyzok521@gmail.com
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2010 - 2018, Cake Development Corporation (https://www.cakedc.com)
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ *
+ * This file handler styles of templates/plugin/CakeDC/Users/email/html/reset_password.php
+ * 
+ * */
+?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">
+<html>
+<head>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= $this->fetch('title') ?></title>
+    <style>
+          * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        padding: 0;
+		background-color: #d9dffa;
+		margin: 0;
+		padding: 0;
+		-webkit-text-size-adjust: none;
+		text-size-adjust: none;
+      }
+
+      table{
+		    mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+	  }
+    
+    table img{
+      display: block;
+      height: auto;
+      border: 0;
+      width: 100%;
+    }
+      a[x-apple-data-detectors] {
+        color: inherit !important;
+        text-decoration: inherit !important;
+      }
+
+      #MessageViewBody a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      p {
+        line-height: inherit;
+      }
+
+      .desktop_hide,
+      .desktop_hide table {
+        mso-hide: all;
+        display: none;
+        max-height: 0px;
+        overflow: hidden;
+      }
+
+      .image_block img + div {
+        display: none;
+      }
+
+      @media (max-width: 620px) {
+        .desktop_hide table.icons-inner {
+          display: inline-block !important;
+        }
+
+        .icons-inner {
+          text-align: center;
+        }
+
+        .icons-inner td {
+          margin: 0 auto;
+        }
+
+        .mobile_hide {
+          display: none;
+        }
+
+        .row-content {
+          width: 100% !important;
+        }
+
+        .stack .column {
+          width: 100%;
+          display: block;
+        }
+
+        .mobile_hide {
+          min-height: 0;
+          max-height: 0;
+          max-width: 0;
+          overflow: hidden;
+          font-size: 0px;
+        }
+
+        .desktop_hide,
+        .desktop_hide table {
+          display: table !important;
+          max-height: none !important;
+        }
+      }
+
+	  .nl-container{
+		background-color: #d9dffa;
+	  }
+
+	  .row .row-1{
+		background-color: #cfd6f4;
+	  }
+
+    .row .row-2 {
+      background-color: #d9dffa;
+    }
+
+    .row .row-5{
+      background-color: #ffffff;
+    }
+
+	  .row-content .stack{
+		color: #000000;
+		width: 600px;
+		margin: 0 auto;
+	  }
+
+    .column .column-1{
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+      font-weight: 400;
+      text-align: left;
+      padding-top: 20px;
+      vertical-align: top;
+      border-top: 0px;
+      border-right: 0px;
+      border-bottom: 0px;
+      border-left: 0px;
+    }
+    
+    .alignment{
+      line-height: 10px
+    }
+
+    .paragraph_block .block-1, .block-2, .block-3, .block-5, .block-6{
+      word-break: break-word;
+    }
+
+    .pad div {
+      color: #506bec;
+      font-family: Helvetica Neue, Helvetica,
+        Arial, sans-serif;
+      font-size: 38px;
+      line-height: 120%;
+      mso-line-height-alt: 45.6px;
+    }
+
+    .pad div p {
+      margin: 0; word-break: break-word
+    }
+
+    .pad .alignment a{
+      text-decoration: none;
+      display: inline-block;
+      color: #ffffff;
+      background-color: #506bec;
+      border-radius: 16px;
+      width: auto;
+      border-top: 0px solid TRANSPARENT;
+      font-weight: undefined;
+      border-right: 0px solid TRANSPARENT;
+      border-bottom: 0px solid TRANSPARENT;
+      border-left: 0px solid TRANSPARENT;
+      padding-top: 8px;
+      padding-bottom: 8px;
+      font-family: Helvetica Neue, Helvetica,
+        Arial, sans-serif;
+      font-size: 15px;
+      text-align: center;
+      mso-border-alt: none;
+      word-break: keep-all;
+    }
+
+    .pad .alignment a span {
+      padding-left: 25px;
+      padding-right: 20px;
+      font-size: 15px;
+      display: inline-block;
+      letter-spacing: normal;
+    }
+
+    .pad .alignment a span span{
+      word-break: break-word
+    }
+
+    .pad .alignment a span span span{
+      line-height: 30px
+    }  
+    </style>
+</head>
+<body>
+    <?= $this->fetch('content') ?>
+</body>
+</html>


### PR DESCRIPTION
# Features

Added template email for reset password.


## Screenshots

![App Screenshot](https://imgur.com/K6iHgA7.png?text=App+Screenshot+Here)

## Path

```
templates
 └──|- plugin
  |	├── CakeDC
  |	│   └── Users
  |	│       ├── email
  |	│       │   └── html
  |	│       │       └── reset_password.php
  |	│       └── layout
  |	│           └── email
  |	│               └── html
  |	│                   └── default.php
```

:information_source: The easy way to create the template was using tables. All CSS styles are in `layout/email/html/default.php`